### PR TITLE
Update Gradle tooling for Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Android build with newer Flutter versions
+
+Recent Flutter releases bundle JDK 17 which requires newer Gradle tooling. If
+the build fails with a message similar to:
+
+```
+[!] Your project's Gradle version is incompatible with the Java version that Flutter is using for Gradle.
+```
+
+update the Gradle plugin and wrapper with the following versions:
+
+```
+android/build.gradle:
+  ext.kotlin_version = '1.8.10'
+  classpath 'com.android.tools.build:gradle:7.4.2'
+
+android/gradle/wrapper/gradle-wrapper.properties:
+  distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+```
+
+These versions are compatible with the Java runtime shipped with Flutter.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
## Summary
- bump Kotlin and Android Gradle plugin versions
- update Gradle wrapper
- document how to resolve the Java/Gradle compatibility error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ba6cd449c8327a8477a3a9c4483f0